### PR TITLE
Fix: Configure Vercel rewrites for API routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,12 @@
 {
   "rewrites": [
     {
+      "source": "/api/(.*)",
+      "destination": "/server/index.js"
+    },
+    {
       "source": "/(.*)",
       "destination": "/index.html"
     }
   ]
-} 
+}


### PR DESCRIPTION
The previous `vercel.json` configuration routed all traffic to `index.html`, which is suitable for an SPA but prevented API requests from reaching the Node.js backend server.

This change updates `vercel.json` to include a specific rewrite rule for paths starting with `/api/`. These requests are now correctly routed to `server/index.js`, allowing the backend to handle API calls such as Patreon verification. The existing catch-all rule for the SPA remains in place for other requests.